### PR TITLE
feat(openssl): add support for creating root CA

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,56 @@ The server and client have the following dependencies.
     -rw-r--r--  1 cdundee  staff  2446 Jul 26 17:04 tedge-certificate.pem
     -rw-r--r--  1 cdundee  staff  1704 Jul 26 17:04 tedge-private-key.pem
     ```
+
+### openssl
+
+Create device certificates using a local CA which is on the same device that the certificates are being created on.
+
+**Pre-requisites**
+
+**Client**
+
+* openssl
+
+1. Generate the root CA certificate
+
+    ```sh
+    ./openssl/pki-openssl ca
+    ```
+
+2. Upload the CA certificate to Cumulocity IoT (if you have not already done so)
+
+    Using [go-c8y-cli](https://goc8ycli.netlify.app/), you can upload the `ca.pem` certificate to Cumulocity IoT.
+
+    ```sh
+    c8y devicemanagement certificates create \
+        --autoRegistrationEnabled \
+        --file ./ca.pem \
+        --name "Local thin-edge.io CA" \
+        --status ENABLED
+    ```
+
+    Alternatively, you can manually upload the `ca.pem` file using the Cumulocity IoT Device Management application under `Trusted Certificates`.
+
+    **Note**
+
+    * Uploading a trusted certificate requires the `ROLE_TENANT_MANAGEMENT_ADMIN` or `ROLE_TENANT_ADMIN` permissions.
+
+3. Run the client pki script to generate new cert pair (public and private key)
+
+    ```sh
+    ./openssl/pki-openssl new mycustomname
+    ```
+
+    Inspect the output files
+
+    ```sh
+    ls -l *.csr tedge*
+    ```
+
+    *Output*
+
+    ```sh
+    -rw-r--r--  1 cdundee  staff  2446 Jul 26 17:04 tedge-certificate.pem
+    -rw-r--r--  1 cdundee  staff  1704 Jul 26 17:04 tedge-private-key.pem
+    ```

--- a/openssl/pki-openssl
+++ b/openssl/pki-openssl
@@ -21,6 +21,8 @@ Dependencies:
     * openssl
 
 Usage
+    $0 ca
+
     $0 new [common_name]
 
     $0 sign [csr_file]
@@ -40,6 +42,9 @@ Flag:
     --help|-h                  Show help
 
 Examples
+    $0 ca
+    \$ Create a root CA if it does not already exist
+
     $0 new testdevice001
     \$ Create a new cert key pair with the common name 'tedgedevice001'
 
@@ -314,7 +319,32 @@ check_ca() {
 
 gen_ca() {
     info "[gen_ca]: Generating CA cert is currently not supported"
-    exit 1
+
+    if [ ! -f "$CA_KEY" ]; then
+        if [ -n "$CA_KEY_BASE64" ]; then
+            info "[load_ca] loading root ca key from env"
+            echo "$CA_KEY_BASE64" | base64 -d > "$CA_KEY"
+        else
+            info "[load_ca] creating new root ca key"
+            openssl genrsa -out "$CA_KEY" 4096 >/dev/null
+        fi
+    fi
+
+    if [ -n "$CA_CERT_BASE64" ]; then
+        info "[load_ca] loading root ca certificate from env"
+        echo "$CA_CERT_BASE64" | base64 -d > "$CA_CERT"
+    else
+        info "[load_ca] creating new root ca certificate"
+
+        openssl req -x509 \
+            -new \
+            -nodes \
+            -subj "/O=Thin Edge/OU=Device Signer" \
+            -key "$CA_KEY" \
+            -sha256 \
+            -days 1024 \
+            -out "$CA_CERT"
+    fi
 }
 
 sign() {
@@ -346,18 +376,7 @@ commit() {
 }
 
 load_ca() {
-    # Check if a local cert is provided via env variables
-    if [ ! -f "$$CA_KEY" ]; then
-        if [ -n "$CA_KEY_BASE64" ]; then
-            echo "$CA_KEY_BASE64" | base64 -d > "$CA_KEY"
-        fi
-    fi
-
-    if [ ! -f "$$CA_CERT" ]; then
-        if [ -n "$CA_CERT_BASE64" ]; then
-            echo "$CA_CERT_BASE64" | base64 -d > "$CA_CERT"
-        fi
-    fi
+    check_ca || gen_ca
 }
 
 new_cert() {
@@ -404,6 +423,9 @@ delete_certs() {
 # ----------------------------
 # log "command: '$COMMAND'"
 case "$COMMAND" in
+    ca)
+        load_ca
+        ;;
     new)
         load_ca
         new_cert "$@"


### PR DESCRIPTION
Add support for the generation of the root CA if it does not already exist and add README instructions