### PR TITLE
feat(cfssl): package as container and general improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 .DS_Store
 *.srl
 *.key
+.env

--- a/cfssl/pki-cfssl
+++ b/cfssl/pki-cfssl
@@ -222,10 +222,19 @@ new_cert() {
     if [ $# -ge 1 ]; then
         cn="$1"
     fi
+
+    # If common name is empty try setting it from known places
+    if [ -z "$cn" ] && command -V tedge-identity >/dev/null 2>&1; then
+        cn=$(tedge-identity)
+    fi
+    if [ -z "$cn" ] && command -V hostname >/dev/null 2>&1; then
+        cn="te_$(hostname)"
+    fi
+
+    # check if it is still empty
     if [ -z "$cn" ]; then
-        if command -V hostname >/dev/null 2>&1; then
-            cn="te_$(hostname)"
-        fi
+        log "ERROR: Could not detect a sensible Common Name for the certificate"
+        exit 1
     fi
 
     # TODO: Add option to force recreation of cert even if certs already exist

--- a/cfssl/pki-cfssl
+++ b/cfssl/pki-cfssl
@@ -200,7 +200,11 @@ sign() {
     csr="$1"
     log "Sending signing request: $csr"
 
-    csr_contents=$(sed ':a;N;$!ba;s/\n/\\n/g' "$csr")
+    GSED="sed"
+    if command -V gsed >/dev/null 2>&1; then
+        GSED="gsed"
+    fi
+    csr_contents=$("$GSED" ':a;N;$!ba;s/\n/\\n/g' "$csr")
     # Alternative to replace the literal newline with escaped newline
     # csr_contents=$(sed 's/$/\\n/g' "$csr" | tr -d '\n')
 

--- a/cfssl/server/Dockerfile
+++ b/cfssl/server/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.22-alpine as build
+
+RUN mkdir -p /tools/bin/ \
+    && GOBIN=/tools/bin/ CGO_ENABLED=0 go install -ldflags '-s -w' github.com/cloudflare/cfssl/cmd/...@latest \
+    && chmod a+x /tools/bin/*
+
+# Final image
+FROM alpine:3.18
+
+VOLUME [ "/data" ]
+COPY --from=build /tools/bin/cfssl /usr/bin/
+COPY --from=build /tools/bin/cfssljson /usr/bin/
+
+WORKDIR /app
+COPY entrypoint.sh csr.json ./
+CMD [ "/app/entrypoint.sh" ]

--- a/cfssl/server/csr.json
+++ b/cfssl/server/csr.json
@@ -9,7 +9,7 @@
     },
     "names": [
         {
-            "O":  "Thin Edge",
+            "O":  "thin-edge.io",
             "OU": "CustomPKI"
         }
     ]

--- a/cfssl/server/docker-compose.yaml
+++ b/cfssl/server/docker-compose.yaml
@@ -1,0 +1,23 @@
+version: "3"
+services:
+  pki:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - CA_CERT_CONTENTS_KEY=${CA_CERT_CONTENTS_KEY:-}
+      - CA_CERT_CONTENTS_PUB=${CA_CERT_CONTENTS_PUB:-}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    ports:
+      - 8888:8888
+    network_mode: host
+
+# Other containers
+# 
+# docker run -it --add-host "host.docker.internal:host-gateway" --rm debian:12-slim
+# Then inside the container use: curl host.docker.internal:8888/api/v1/cfssl/newcert
+
+# Or using docker compose
+# extra_hosts:
+#     - "host.docker.internal:host-gateway"

--- a/cfssl/server/entrypoint.sh
+++ b/cfssl/server/entrypoint.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+help() {
+    echo "
+Start a PKI server. If the CA certificate will be created if they do not already exist
+
+Usage
+    $0
+
+Examples
+    $0
+    \$ Start a pki server which reachable via 127.0.0.1:8888
+"
+}
+
+dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+
+CA_CERT_DIR=${CA_CERT_DIR:-/data}
+CA_CERT_KEY=${CA_CERT_KEY:-$CA_CERT_DIR/ca-key.pem}
+CA_CERT_PUB=${CA_CERT_PUB:-$CA_CERT_DIR/ca.pem}
+MUTUAL_TLS_CA=${MUTUAL_TLS_CA:-$CA_CERT_DIR/mutual-tls-ca.pem}
+
+if [ -n "$CA_CERT_CONTENTS_KEY" ]; then
+    echo "Loading CA cert key from env variable: CERT_CONTENTS_KEY" >&2
+    printf "%s" "$CA_CERT_CONTENTS_KEY" | base64 -d > "$CA_CERT_KEY"
+fi
+
+if [ -n "$CA_CERT_CONTENTS_PUB" ]; then
+    echo "Loading CA cert file from env variable: CERT_CONTENTS_PUB" >&2
+    printf "%s" "$CA_CERT_CONTENTS_PUB" | base64 -d > "$CA_CERT_PUB"
+fi
+
+if [ ! -f "$CA_CERT_KEY" ] || [ ! -f "$CA_CERT_PUB" ]; then
+    echo "[cfssl] Initializing the CA" >&2
+    cfssl genkey -initca "$dir/csr.json" | cfssljson -bare ca
+fi
+
+if [ -n "$MUTUAL_TLS_CA_CONTENTS" ]; then
+    echo "Loading mutual TLS CA cert file from env variable: MUTUAL_TLS_CA_CONTENTS" >&2
+    printf "%s" "$CA_CERT_CONTENTS_PUB" | base64 -d > "$MUTUAL_TLS_CA"
+fi
+
+if [ -f "$MUTUAL_TLS_CA" ]; then
+    echo "[cfssl] Starting PKI server with mutual TLS client validation" >&2
+    exec cfssl serve -ca-key "$CA_CERT_KEY" -ca "$CA_CERT_PUB" -mutual-tls-ca "$MUTUAL_TLS_CA" "$@"
+else
+    echo "[cfssl] Starting PKI server" >&2
+    exec cfssl serve -ca-key "$CA_CERT_KEY" -ca "$CA_CERT_PUB" "$@"
+fi

--- a/justfile
+++ b/justfile
@@ -15,3 +15,7 @@ build:
 # Publish packages
 publish *args="":
     ./ci/publish.sh --path "{{package_dir}}" {{args}}
+
+# Start a cfssl server
+start-cfssl-server *ARGS:
+    docker compose --build -f cfssl/server/docker-compose.yaml up {{ARGS}}

--- a/justfile
+++ b/justfile
@@ -18,4 +18,4 @@ publish *args="":
 
 # Start a cfssl server
 start-cfssl-server *ARGS:
-    docker compose --build -f cfssl/server/docker-compose.yaml up {{ARGS}}
+    docker compose -f cfssl/server/docker-compose.yaml up --build {{ARGS}}

--- a/renewer/renew.sh
+++ b/renewer/renew.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+#
+# Settings
+#
+DEFAULT_BASEDIR=${DEFAULT_BASEDIR:-/etc/tedge/device-certs}
+BASEDIR="${BASEDIR:-}"
+DEVICE_CERT="${DEVICE_CERT:-}"
+MIN_VALIDITY_SEC=${MIN_VALIDITY_SEC:-}
+
+if [ -z "$BASEDIR" ]; then
+    if [ -d "$DEFAULT_BASEDIR" ]; then
+        BASEDIR="$DEFAULT_BASEDIR"
+    else
+        # default to current directory
+        BASEDIR="."
+    fi
+fi
+
+if [ -z "$MIN_VALIDITY_SEC" ] || [ "$MIN_VALIDITY_SEC" -lt 60 ]; then
+    # 604800  = (7 days in seconds)
+    MIN_VALIDITY_SEC="604800"
+fi
+
+if [ -z "$DEVICE_CERT" ]; then
+    DEVICE_CERT="$BASEDIR/tedge-certificate.pem"
+fi
+
+#
+# Functions
+#
+expires_soon() {
+    if openssl x509 -checkend "$MIN_VALIDITY_SEC" -noout -in "$DEVICE_CERT" >/dev/null 2>&1; then
+        echo "Certificate does not expire within $MIN_VALIDITY_SEC seconds" >&2
+        return 1
+    fi
+
+    echo "Certificate expires within $MIN_VALIDITY_SEC seconds" >&2
+    return 0
+}
+
+renew() {
+    echo "Renewing certificate" >&2
+    TEDGE="tedge"
+    if command -V tedge-cli >/dev/null 2>&1; then
+        TEDGE="tedge-cli"
+    fi
+    "$TEDGE" cert create-csr --output-path "/tmp/tedge.csr"
+    pki-cfssl sign "/tmp/tedge.csr"
+}
+
+#
+# main
+#
+main() {
+    if expires_soon; then
+        renew
+    fi
+}
+
+main

--- a/renewer/renew.sh
+++ b/renewer/renew.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 #
 # Settings
@@ -45,6 +46,7 @@ renew() {
     if command -V tedge-cli >/dev/null 2>&1; then
         TEDGE="tedge-cli"
     fi
+    rm -f "/tmp/tedge.csr"
     "$TEDGE" cert create-csr --output-path "/tmp/tedge.csr"
     pki-cfssl sign "/tmp/tedge.csr"
 }


### PR DESCRIPTION
* fail on unexpected errors
* build container when launch via docker compose up
* add simple renewal script
* use official thin-edge.io product name
* dev: add task to launch the cfssl using docker compose
* feat(cfssl): use tedge-identity when generating common name (if available)